### PR TITLE
Support https url's in bakery configuration

### DIFF
--- a/oebakery/parse.py
+++ b/oebakery/parse.py
@@ -425,7 +425,7 @@ def parse_bakery_conf():
                 params["pythonpath"] = "lib"
             if not "oerecipes" in params:
                 params["oerecipes"] = "*/*.oe"
-        if "srcuri" in params and params["srcuri"].startswith("git://"):
+        if "srcuri" in params:
             if not "protocol" in params:
                 params["protocol"] = "git"
         if path in gitmodules:
@@ -437,8 +437,8 @@ def parse_bakery_conf():
                         "mismatch between .gitmodules url and srcuri for %s",
                         path)
             config["__submodules"].append((path, url, params))
-        elif "srcuri" in params and params["srcuri"].startswith("git://"):
-            url = "%s%s"%(params["protocol"], params["srcuri"][3:])
+        elif "srcuri" in params:
+            url = "%s%s"%(params["protocol"], params["srcuri"][len(params["protocol"]):])
             config["__submodules"].append((path, url, params))
         config["__oestack"].append((path, params))
         if "oepath" in params:


### PR DESCRIPTION
Trying to follow the oe-lite handbook, I verified that the git url's on the oe-lite website don't work anymore. When I substituted them with the github equivalents, I noticed that bakery didn't work with https git url's. This patch removes the check and allows the use of the https URL's. I left the protocol parameter check unchanged, so the default when there is no protocol parameter is still to use "git". For https, the parameter protocol must be added.